### PR TITLE
WIP feat(istio): support v1alpha3 and v1

### DIFF
--- a/source/istio/common.go
+++ b/source/istio/common.go
@@ -1,0 +1,58 @@
+package istio
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/external-dns/endpoint"
+
+	"sigs.k8s.io/external-dns/source/utils"
+)
+
+// IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
+// instead of a standard LoadBalancer service type
+const IstioGatewayIngressSource = "external-dns.alpha.kubernetes.io/ingress"
+
+type Gateway struct {
+	kubeClient kubernetes.Interface
+}
+
+// NewGateway creates a new Gateway source
+func NewGateway(kubeClient kubernetes.Interface) Gateway {
+	return Gateway{
+		kubeClient: kubeClient,
+	}
+}
+
+func (sc *Gateway) EndpointsFromGateway(_ context.Context, hostnames []string, annotations map[string]string, resource string, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
+	var endpoints []*endpoint.Endpoint
+
+	ttl := utils.TTLFromAnnotations(annotations, resource)
+	providerSpecific, setIdentifier := utils.ProviderSpecificAnnotations(annotations)
+
+	for _, host := range hostnames {
+		endpoints = append(endpoints, utils.EndpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)
+	}
+	return endpoints, nil
+}
+
+// targetsFromIngress extracts targets from an Ingress annotation
+func (sc *Gateway) TargetsFromIngress(ctx context.Context, ingressStr string, namespace string) (endpoint.Targets, error) {
+	ingress, err := sc.kubeClient.NetworkingV1().Ingresses(namespace).Get(ctx, ingressStr, metav1.GetOptions{})
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	var targets endpoint.Targets
+	for _, lb := range ingress.Status.LoadBalancer.Ingress {
+		if lb.IP != "" {
+			targets = append(targets, lb.IP)
+		} else if lb.Hostname != "" {
+			targets = append(targets, lb.Hostname)
+		}
+	}
+	return targets, nil
+}

--- a/source/istio/v1.go
+++ b/source/istio/v1.go
@@ -1,0 +1,66 @@
+package istio
+
+import (
+	"context"
+	"fmt"
+
+	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/source/utils"
+)
+
+func FilterByAnnotationsV1(annotationFilter string, gateways []*networkingv1.Gateway) ([]*networkingv1.Gateway, error) {
+	selector, err := utils.ParseAnnotationFilter(annotationFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	// empty filter returns original list
+	if selector.Empty() {
+		return gateways, nil
+	}
+
+	var filteredList []*networkingv1.Gateway
+
+	for _, gw := range gateways {
+		// convert the annotations to an equivalent label selector
+		annotations := labels.Set(gw.Annotations)
+
+		// include if the annotations match the selector
+		if selector.Matches(annotations) {
+			filteredList = append(filteredList, gw)
+		}
+	}
+
+	return filteredList, nil
+}
+
+func TargetsFromGatewayV1(ctx context.Context, gw Gateway, svcInformer coreinformers.ServiceInformer, gateway *networkingv1.Gateway) (endpoint.Targets, error) {
+	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	if ok && ingressStr != "" {
+		return targetsFromIngressV1(ctx, gw, ingressStr, gateway)
+	}
+	return utils.EndpointTargetsFromServices(svcInformer, gateway.Namespace, gateway.Spec.Selector), nil
+}
+
+func targetsFromIngressV1(ctx context.Context, gw Gateway, ingressStr string, gateway *networkingv1.Gateway) (endpoint.Targets, error) {
+	namespace, name, err := gwNameWithNamespaceV1(ingressStr, gateway)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
+	}
+	return gw.TargetsFromIngress(ctx, name, namespace)
+}
+
+func gwNameWithNamespaceV1(ingressStr string, gateway *networkingv1.Gateway) (string, string, error) {
+	namespace, name, err := utils.ParseIngress(ingressStr)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
+	}
+	if namespace == "" {
+		namespace = gateway.Namespace
+	}
+
+	return name, namespace, nil
+}

--- a/source/istio/v1alpha3.go
+++ b/source/istio/v1alpha3.go
@@ -1,0 +1,68 @@
+package istio
+
+import (
+	"context"
+	"fmt"
+
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/labels"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"sigs.k8s.io/external-dns/endpoint"
+
+	"sigs.k8s.io/external-dns/source/utils"
+)
+
+// filterByAnnotationsV1Alpha3 filters a list of configs by a given annotation selector.
+func FilterByAnnotationsV1Alpha3(annotationFilter string, gateways []*networkingv1alpha3.Gateway) ([]*networkingv1alpha3.Gateway, error) {
+	selector, err := utils.ParseAnnotationFilter(annotationFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	// empty filter returns original list
+	if selector.Empty() {
+		return gateways, nil
+	}
+
+	var filteredList []*networkingv1alpha3.Gateway
+
+	for _, gw := range gateways {
+		// convert the annotations to an equivalent label selector
+		annotations := labels.Set(gw.Annotations)
+
+		// include if the annotations match the selector
+		if selector.Matches(annotations) {
+			filteredList = append(filteredList, gw)
+		}
+	}
+
+	return filteredList, nil
+}
+
+func TargetsFromGatewayV1Alpha3(ctx context.Context, gw Gateway, svcInformer coreinformers.ServiceInformer, gateway *networkingv1alpha3.Gateway) (endpoint.Targets, error) {
+	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	if ok && ingressStr != "" {
+		return targetsFromIngressV1Alpha3(ctx, gw, ingressStr, gateway)
+	}
+	return utils.EndpointTargetsFromServices(svcInformer, gateway.Namespace, gateway.Spec.Selector), nil
+}
+
+func targetsFromIngressV1Alpha3(ctx context.Context, gw Gateway, ingressStr string, gateway *networkingv1alpha3.Gateway) (endpoint.Targets, error) {
+	namespace, name, err := gwNamespaceWithNameV1Alpha3(ingressStr, gateway)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
+	}
+	return gw.TargetsFromIngress(ctx, name, namespace)
+}
+
+func gwNamespaceWithNameV1Alpha3(ingressStr string, gateway *networkingv1alpha3.Gateway) (string, string, error) {
+	namespace, name, err := utils.ParseIngress(ingressStr)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
+	}
+	if namespace == "" {
+		namespace = gateway.Namespace
+	}
+
+	return name, namespace, nil
+}

--- a/source/istio_eventhanlders.go
+++ b/source/istio_eventhanlders.go
@@ -1,0 +1,17 @@
+package source
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// AddEventHandler adds an event handler that should be triggered if the watched Istio Gateway changes.
+func (sc *gatewaySource) AddEventHandler(ctx context.Context, handler func()) {
+	log.Debug("Adding event handler for Istio Gateway")
+	if sc.gatewayInformerV1 != nil {
+		sc.gatewayInformerV1.Informer().AddEventHandler(eventHandlerFunc(handler))
+	} else {
+		sc.gatewayInformerV1Alpha3.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
+}

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -19,17 +19,22 @@ package source
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
-	"strings"
 	"text/template"
 
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/external-dns/source/istio"
+	// TODO: rename to istiov1
+	v1 "istio.io/client-go/pkg/apis/networking/v1"
+	// TODO: rename to istiov1alpha3
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
+	networkingv1informer "istio.io/client-go/pkg/informers/externalversions/networking/v1"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -54,7 +59,10 @@ type gatewaySource struct {
 	combineFQDNAnnotation    bool
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer
-	gatewayInformer          networkingv1alpha3informer.GatewayInformer
+	gateway                  istio.Gateway
+	gatewayInformerV1        networkingv1informer.GatewayInformer
+	// TODO: keep for backward compatibility. TBD removal in future releases
+	gatewayInformerV1Alpha3 networkingv1alpha3informer.GatewayInformer
 }
 
 // NewIstioGatewaySource creates a new gatewaySource with the given config.
@@ -73,29 +81,83 @@ func NewIstioGatewaySource(
 		return nil, err
 	}
 
+	// IS networking.istio.io/v1 or networking.istio.io/v1alpha3
+	version := "v1"
+	_, e := istioClient.Discovery().ServerResourcesForGroupVersion("networking.istio.io/v1")
+	if e != nil {
+		log.Warningf("istio CRD version 'networking.istio.io/v1' not installed %s", e)
+		log.Warning("in future releases only 'networking.istio.io/v1' will be supported")
+		_, e = istioClient.Discovery().ServerResourcesForGroupVersion("networking.istio.io/v1alpha3")
+		if e != nil {
+			return nil, fmt.Errorf("istio CRD version 'networking.istio.io/v1alpha3' not installed %s", e)
+		} else {
+			version = "v1alpha3"
+		}
+	}
+
 	// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
 	// Set resync period to 0, to prevent processing when nothing has changed
 	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(namespace))
 	serviceInformer := informerFactory.Core().V1().Services()
 	istioInformerFactory := istioinformers.NewSharedInformerFactory(istioClient, 0)
-	gatewayInformer := istioInformerFactory.Networking().V1alpha3().Gateways()
 
 	// Add default resource event handlers to properly initialize informer.
 	serviceInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				log.Debug("service added")
+				// TODO: test this
+				if log.IsLevelEnabled(log.DebugLevel) {
+					service, ok := obj.(*corev1.Service)
+					if !ok {
+						log.Errorf("event handler not added. unexpected type '%s' when should be 'service/v1'", reflect.TypeOf(obj).String())
+						return
+					} else {
+						log.Debugf("event handler added for 'service/v1' in 'namespace:%s' with 'name:%s'.", service.Name, service.Namespace)
+					}
+				}
 			},
 		},
 	)
 
-	gatewayInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				log.Debug("gateway added")
+	var gwInformerV1 networkingv1informer.GatewayInformer
+	var gwInformerV1Alpha3 networkingv1alpha3informer.GatewayInformer
+
+	if version == "v1" {
+		gwInformerV1 = istioInformerFactory.Networking().V1().Gateways()
+		gwInformerV1.Informer().AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					// TODO: test this
+					if log.IsLevelEnabled(log.DebugLevel) {
+						service, ok := obj.(*v1.Gateway)
+						if !ok {
+							log.Errorf("event handler not added. unexpected type '%s' when should be 'gateway.networking.istio.io/v1", reflect.TypeOf(obj).String())
+							return
+						} else {
+							log.Debugf("event handler added for 'gateway.networking.istio.io/v1' in 'namespace:%s' with 'name:%s'", service.Name, service.Namespace)
+						}
+					}
+				},
 			},
-		},
-	)
+		)
+	} else {
+		gwInformerV1Alpha3 = istioInformerFactory.Networking().V1alpha3().Gateways()
+		gwInformerV1Alpha3.Informer().AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					// TODO: test this
+					log.Debug("gateway added V1alpha3")
+					service, ok := obj.(*networkingv1alpha3.Gateway)
+					if !ok {
+						log.Errorf("event handler not added. unexpected type '%s' when should be 'gateway.networking.istio.io/v1alpha3'", reflect.TypeOf(obj).String())
+						return
+					} else {
+						log.Debugf("event handler added for 'gateway.networking.istio.io/v1alpha3' in 'namespace:%s' with 'name:%s'", service.Name, service.Namespace)
+					}
+				},
+			},
+		)
+	}
 
 	informerFactory.Start(ctx.Done())
 	istioInformerFactory.Start(ctx.Done())
@@ -117,27 +179,52 @@ func NewIstioGatewaySource(
 		combineFQDNAnnotation:    combineFQDNAnnotation,
 		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
 		serviceInformer:          serviceInformer,
-		gatewayInformer:          gatewayInformer,
+		gateway:                  istio.NewGateway(kubeClient),
+		gatewayInformerV1:        gwInformerV1,
+		gatewayInformerV1Alpha3:  gwInformerV1Alpha3,
 	}, nil
 }
 
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all gateway resources in the source's namespace(s).
 func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
-	gwList, err := sc.istioClient.NetworkingV1alpha3().Gateways(sc.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	gateways := gwList.Items
-	gateways, err = sc.filterByAnnotations(gateways)
-	if err != nil {
-		return nil, err
-	}
-
 	var endpoints []*endpoint.Endpoint
+	var err error
+
+	if sc.gatewayInformerV1 != nil {
+		endpoints, err = sc.ExecuteV1(ctx, endpoints)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		endpoints, err = sc.ExecuteV1Alpha3(ctx, endpoints)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, ep := range endpoints {
+		sort.Sort(ep.Targets)
+	}
+
+	return endpoints, nil
+}
+
+func (sc *gatewaySource) ExecuteV1(ctx context.Context, endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	apiVersion := "networking.istio.io/v1"
+	gwList, err := sc.istioClient.NetworkingV1().Gateways(sc.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	gateways := gwList.Items
+	gateways, err = istio.FilterByAnnotationsV1(sc.annotationFilter, gateways)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("found '%d' 'gateway.%s'", len(gateways), apiVersion)
 
 	for _, gateway := range gateways {
+		log.Debugf("processing 'gateway.%s' with 'name:%s' in 'namespace:%s'", apiVersion, gateway.Name, gateway.Namespace)
 		// Check controller annotation to see if we are responsible.
 		controller, ok := gateway.Annotations[controllerAnnotationKey]
 		if ok && controller != controllerAnnotationValue {
@@ -145,8 +232,7 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 				gateway.Namespace, gateway.Name, controller, controllerAnnotationValue)
 			continue
 		}
-
-		gwHostnames, err := sc.hostNamesFromGateway(gateway)
+		gwHostnames, err := sc.hostNamesFromGatewayV1(gateway)
 		if err != nil {
 			return nil, err
 		}
@@ -170,7 +256,7 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 			continue
 		}
 
-		gwEndpoints, err := sc.endpointsFromGateway(ctx, gwHostnames, gateway)
+		gwEndpoints, err := sc.endpointsFromGatewayV1(ctx, gwHostnames, gateway)
 		if err != nil {
 			return nil, err
 		}
@@ -183,190 +269,67 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 		log.Debugf("Endpoints generated from gateway: %s/%s: %v", gateway.Namespace, gateway.Name, gwEndpoints)
 		endpoints = append(endpoints, gwEndpoints...)
 	}
-
-	for _, ep := range endpoints {
-		sort.Sort(ep.Targets)
-	}
-
 	return endpoints, nil
 }
 
-// AddEventHandler adds an event handler that should be triggered if the watched Istio Gateway changes.
-func (sc *gatewaySource) AddEventHandler(ctx context.Context, handler func()) {
-	log.Debug("Adding event handler for Istio Gateway")
-
-	sc.gatewayInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
-}
-
-// filterByAnnotations filters a list of configs by a given annotation selector.
-func (sc *gatewaySource) filterByAnnotations(gateways []*networkingv1alpha3.Gateway) ([]*networkingv1alpha3.Gateway, error) {
-	labelSelector, err := metav1.ParseToLabelSelector(sc.annotationFilter)
+func (sc *gatewaySource) ExecuteV1Alpha3(ctx context.Context, endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	apiVersion := "networking.istio.io/v1alpha3"
+	gwList, err := sc.istioClient.NetworkingV1alpha3().Gateways(sc.namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	gateways := gwList.Items
+	gateways, err = istio.FilterByAnnotationsV1Alpha3(sc.annotationFilter, gateways)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("found '%d' 'gateway.%s'", len(gateways), apiVersion)
 
-	// empty filter returns original list
-	if selector.Empty() {
-		return gateways, nil
-	}
-
-	var filteredList []*networkingv1alpha3.Gateway
-
-	for _, gw := range gateways {
-		// convert the annotations to an equivalent label selector
-		annotations := labels.Set(gw.Annotations)
-
-		// include if the annotations match the selector
-		if selector.Matches(annotations) {
-			filteredList = append(filteredList, gw)
-		}
-	}
-
-	return filteredList, nil
-}
-
-func parseIngress(ingress string) (namespace, name string, err error) {
-	parts := strings.Split(ingress, "/")
-	if len(parts) == 2 {
-		namespace, name = parts[0], parts[1]
-	} else if len(parts) == 1 {
-		name = parts[0]
-	} else {
-		err = fmt.Errorf("invalid ingress name (name or namespace/name) found %q", ingress)
-	}
-
-	return
-}
-
-func (sc *gatewaySource) targetsFromIngress(ctx context.Context, ingressStr string, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
-	namespace, name, err := parseIngress(ingressStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
-	}
-	if namespace == "" {
-		namespace = gateway.Namespace
-	}
-
-	ingress, err := sc.kubeClient.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		log.Error(err)
-		return
-	}
-	for _, lb := range ingress.Status.LoadBalancer.Ingress {
-		if lb.IP != "" {
-			targets = append(targets, lb.IP)
-		} else if lb.Hostname != "" {
-			targets = append(targets, lb.Hostname)
-		}
-	}
-	return
-}
-
-func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
-	targets = getTargetsFromTargetAnnotation(gateway.Annotations)
-	if len(targets) > 0 {
-		return
-	}
-
-	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
-	if ok && ingressStr != "" {
-		targets, err = sc.targetsFromIngress(ctx, ingressStr, gateway)
-		return
-	}
-
-	services, err := sc.serviceInformer.Lister().Services(sc.namespace).List(labels.Everything())
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	for _, service := range services {
-		if !gatewaySelectorMatchesServiceSelector(gateway.Spec.Selector, service.Spec.Selector) {
+	for _, gateway := range gateways {
+		log.Debugf("processing 'gateway.%s' with 'name:%s' in 'namespace:%s'", apiVersion, gateway.Name, gateway.Namespace)
+		// Check controller annotation to see if we are responsible.
+		controller, ok := gateway.Annotations[controllerAnnotationKey]
+		if ok && controller != controllerAnnotationValue {
+			log.Debugf("Skipping gateway %s/%s because controller value does not match, found: %s, required: %s",
+				gateway.Namespace, gateway.Name, controller, controllerAnnotationValue)
 			continue
 		}
-
-		if len(service.Spec.ExternalIPs) > 0 {
-			targets = append(targets, service.Spec.ExternalIPs...)
-			continue
-		}
-
-		for _, lb := range service.Status.LoadBalancer.Ingress {
-			if lb.IP != "" {
-				targets = append(targets, lb.IP)
-			} else if lb.Hostname != "" {
-				targets = append(targets, lb.Hostname)
-			}
-		}
-	}
-
-	return
-}
-
-// endpointsFromGatewayConfig extracts the endpoints from an Istio Gateway Config object
-func (sc *gatewaySource) endpointsFromGateway(ctx context.Context, hostnames []string, gateway *networkingv1alpha3.Gateway) ([]*endpoint.Endpoint, error) {
-	var endpoints []*endpoint.Endpoint
-	var err error
-
-	resource := fmt.Sprintf("gateway/%s/%s", gateway.Namespace, gateway.Name)
-
-	annotations := gateway.Annotations
-	ttl := getTTLFromAnnotations(annotations, resource)
-
-	targets := getTargetsFromTargetAnnotation(annotations)
-	if len(targets) == 0 {
-		targets, err = sc.targetsFromGateway(ctx, gateway)
+		gwHostnames, err := sc.hostNamesFromGatewayV1Alpha3(gateway)
 		if err != nil {
 			return nil, err
 		}
+
+		// apply template if host is missing on gateway
+		if (sc.combineFQDNAnnotation || len(gwHostnames) == 0) && sc.fqdnTemplate != nil {
+			iHostnames, err := execTemplate(sc.fqdnTemplate, gateway)
+			if err != nil {
+				return nil, err
+			}
+
+			if sc.combineFQDNAnnotation {
+				gwHostnames = append(gwHostnames, iHostnames...)
+			} else {
+				gwHostnames = iHostnames
+			}
+		}
+
+		if len(gwHostnames) == 0 {
+			log.Debugf("No hostnames could be generated from gateway %s/%s", gateway.Namespace, gateway.Name)
+			continue
+		}
+
+		gwEndpoints, err := sc.endpointsFromGatewayV1Alpha3(ctx, gwHostnames, gateway)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(gwEndpoints) == 0 {
+			log.Debugf("No endpoints could be generated from gateway %s/%s", gateway.Namespace, gateway.Name)
+			continue
+		}
+
+		log.Debugf("Endpoints generated from gateway: %s/%s: %v", gateway.Namespace, gateway.Name, gwEndpoints)
+		endpoints = append(endpoints, gwEndpoints...)
 	}
-
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
-
-	for _, host := range hostnames {
-		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)
-	}
-
 	return endpoints, nil
-}
-
-func (sc *gatewaySource) hostNamesFromGateway(gateway *networkingv1alpha3.Gateway) ([]string, error) {
-	var hostnames []string
-	for _, server := range gateway.Spec.Servers {
-		for _, host := range server.Hosts {
-			if host == "" {
-				continue
-			}
-
-			parts := strings.Split(host, "/")
-
-			// If the input hostname is of the form my-namespace/foo.bar.com, remove the namespace
-			// before appending it to the list of endpoints to create
-			if len(parts) == 2 {
-				host = parts[1]
-			}
-
-			if host != "*" {
-				hostnames = append(hostnames, host)
-			}
-		}
-	}
-
-	if !sc.ignoreHostnameAnnotation {
-		hostnames = append(hostnames, getHostnamesFromAnnotations(gateway.Annotations)...)
-	}
-
-	return hostnames, nil
-}
-
-func gatewaySelectorMatchesServiceSelector(gwSelector, svcSelector map[string]string) bool {
-	for k, v := range gwSelector {
-		if lbl, ok := svcSelector[k]; !ok || lbl != v {
-			return false
-		}
-	}
-	return true
 }

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -499,7 +499,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			gatewayCfg := ti.config.Config()
 			if source, err := newTestGatewaySource(ti.lbServices, ti.ingresses); err != nil {
 				require.NoError(t, err)
-			} else if hostnames, err := source.hostNamesFromGateway(gatewayCfg); err != nil {
+			} else if hostnames, err := source.hostNamesFromGatewayV1Alpha3(gatewayCfg); err != nil {
 				require.NoError(t, err)
 			} else if endpoints, err := source.endpointsFromGateway(context.Background(), hostnames, gatewayCfg); err != nil {
 				require.NoError(t, err)

--- a/source/istio_versioned.go
+++ b/source/istio_versioned.go
@@ -1,0 +1,108 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	// log "github.com/sirupsen/logrus"
+	// "k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/source/utils"
+
+	"sigs.k8s.io/external-dns/source/istio"
+
+	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+)
+
+// endpointsFromGatewayConfig extracts the endpoints from an Istio Gateway Config object
+func (sc *gatewaySource) endpointsFromGatewayV1Alpha3(ctx context.Context, hostnames []string, gw *networkingv1alpha3.Gateway) ([]*endpoint.Endpoint, error) {
+	resource := fmt.Sprintf("gateway/%s/%s", gw.Namespace, gw.Name)
+
+	annotations := gw.Annotations
+
+	targets := utils.TargetsFromTargetAnnotation(annotations)
+	if len(targets) == 0 {
+		var err error
+		targets, err = istio.TargetsFromGatewayV1Alpha3(ctx, sc.gateway, sc.serviceInformer, gw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sc.gateway.EndpointsFromGateway(ctx, hostnames, annotations, resource, targets)
+}
+
+func (sc *gatewaySource) endpointsFromGatewayV1(ctx context.Context, hostnames []string, gw *networkingv1.Gateway) ([]*endpoint.Endpoint, error) {
+	resource := fmt.Sprintf("gateway/%s/%s", gw.Namespace, gw.Name)
+	annotations := gw.Annotations
+
+	targets := utils.TargetsFromTargetAnnotation(annotations)
+	if len(targets) == 0 {
+		var err error
+		targets, err = istio.TargetsFromGatewayV1(ctx, sc.gateway, sc.serviceInformer, gw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return sc.gateway.EndpointsFromGateway(ctx, hostnames, annotations, resource, targets)
+}
+
+func (sc *gatewaySource) hostNamesFromGatewayV1Alpha3(gateway *networkingv1alpha3.Gateway) ([]string, error) {
+	var hostnames []string
+	for _, server := range gateway.Spec.Servers {
+		for _, host := range server.Hosts {
+			if host == "" {
+				continue
+			}
+
+			parts := strings.Split(host, "/")
+
+			// If the input hostname is of the form my-namespace/foo.bar.com, remove the namespace
+			// before appending it to the list of endpoints to create
+			if len(parts) == 2 {
+				host = parts[1]
+			}
+
+			if host != "*" {
+				hostnames = append(hostnames, host)
+			}
+		}
+	}
+
+	if !sc.ignoreHostnameAnnotation {
+		hostnames = append(hostnames, getHostnamesFromAnnotations(gateway.Annotations)...)
+	}
+
+	return hostnames, nil
+}
+
+func (sc *gatewaySource) hostNamesFromGatewayV1(gateway *networkingv1.Gateway) ([]string, error) {
+	var hostnames []string
+	for _, server := range gateway.Spec.Servers {
+		for _, host := range server.Hosts {
+			if host == "" {
+				continue
+			}
+
+			parts := strings.Split(host, "/")
+
+			// If the input hostname is of the form my-namespace/foo.bar.com, remove the namespace
+			// before appending it to the list of endpoints to create
+			if len(parts) == 2 {
+				host = parts[1]
+			}
+
+			if host != "*" {
+				hostnames = append(hostnames, host)
+			}
+		}
+	}
+
+	if !sc.ignoreHostnameAnnotation {
+		hostnames = append(hostnames, getHostnamesFromAnnotations(gateway.Annotations)...)
+	}
+
+	return hostnames, nil
+}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -35,6 +35,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/external-dns/source/utils"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -435,7 +436,7 @@ func parseGateway(gateway string) (namespace, name string, err error) {
 }
 
 func (sc *virtualServiceSource) targetsFromIngress(ctx context.Context, ingressStr string, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
-	namespace, name, err := parseIngress(ingressStr)
+	namespace, name, err := utils.ParseIngress(ingressStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
 	}
@@ -477,7 +478,7 @@ func (sc *virtualServiceSource) targetsFromGateway(ctx context.Context, gateway 
 	}
 
 	for _, service := range services {
-		if !gatewaySelectorMatchesServiceSelector(gateway.Spec.Selector, service.Spec.Selector) {
+		if !utils.SelectorMatchesServiceSelector(gateway.Spec.Selector, service.Spec.Selector) {
 			continue
 		}
 

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -33,6 +33,7 @@ import (
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/external-dns/source/utils"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -2036,7 +2037,7 @@ func testGatewaySelectorMatchesService(t *testing.T) {
 		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
-			require.Equal(t, ti.expected, gatewaySelectorMatchesServiceSelector(ti.gwSelector, ti.lbSelector))
+			require.Equal(t, ti.expected, utils.SelectorMatchesServiceSelector(ti.gwSelector, ti.lbSelector))
 		})
 	}
 }

--- a/source/source.go
+++ b/source/source.go
@@ -88,6 +88,7 @@ type Source interface {
 	AddEventHandler(context.Context, func())
 }
 
+// TODO: refactore. moved to source/utils
 func getTTLFromAnnotations(annotations map[string]string, resource string) endpoint.TTL {
 	ttlNotConfigured := endpoint.TTL(0)
 	ttlAnnotation, exists := annotations[ttlAnnotationKey]
@@ -106,6 +107,7 @@ func getTTLFromAnnotations(annotations map[string]string, resource string) endpo
 	return endpoint.TTL(ttlValue)
 }
 
+// TODO: refactore. moved to source/utils
 // parseTTL parses TTL from string, returning duration in seconds.
 // parseTTL supports both integers like "600" and durations based
 // on Go Duration like "10m", hence "600" and "10m" represent the same value.
@@ -182,11 +184,13 @@ func splitHostnameAnnotation(annotation string) []string {
 	return strings.Split(strings.Replace(annotation, " ", "", -1), ",")
 }
 
+// TODO: refactore. moved to source/utils
 func getAliasFromAnnotations(annotations map[string]string) bool {
 	aliasAnnotation, exists := annotations[aliasAnnotationKey]
 	return exists && aliasAnnotation == "true"
 }
 
+// TODO: refactore. moved to source/utils
 func getProviderSpecificAnnotations(annotations map[string]string) (endpoint.ProviderSpecific, string) {
 	providerSpecificAnnotations := endpoint.ProviderSpecific{}
 
@@ -260,6 +264,7 @@ func getTargetsFromTargetAnnotation(annotations map[string]string) endpoint.Targ
 	return targets
 }
 
+// TODO: refactore. moved to source/utils
 // suitableType returns the DNS resource record type suitable for the target.
 // In this case type A/AAAA for IPs and type CNAME for everything else.
 func suitableType(target string) string {
@@ -272,6 +277,7 @@ func suitableType(target string) string {
 	return endpoint.RecordTypeCNAME
 }
 
+// TODO: refactore. move to source/utils
 // endpointsForHostname returns the endpoint objects for each host-target combination.
 func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoint.TTL, providerSpecific endpoint.ProviderSpecific, setIdentifier string, resource string) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint

--- a/source/utils/utils.go
+++ b/source/utils/utils.go
@@ -1,0 +1,289 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+const (
+	// CloudflareProxiedKey The annotation used for determining if traffic will go through Cloudflare
+	CloudflareProxiedKey        = "external-dns.alpha.kubernetes.io/cloudflare-proxied"
+	CloudflareCustomHostnameKey = "external-dns.alpha.kubernetes.io/cloudflare-custom-hostname"
+
+	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
+
+	SetIdentifierKey   = "external-dns.alpha.kubernetes.io/set-identifier"
+	aliasAnnotationKey = "external-dns.alpha.kubernetes.io/alias"
+
+	ttlAnnotationKey = "external-dns.alpha.kubernetes.io/ttl"
+	ttlMinimum       = 1
+	ttlMaximum       = math.MaxInt32
+)
+
+// TTLFromAnnotations TODO: copied from source.go. Refactor to avoid duplication.
+// TTLFromAnnotations extracts the TTL from the annotations of the given resource.
+func TTLFromAnnotations(annotations map[string]string, resource string) endpoint.TTL {
+	ttlNotConfigured := endpoint.TTL(0)
+	ttlAnnotation, exists := annotations[ttlAnnotationKey]
+	if !exists {
+		return ttlNotConfigured
+	}
+	ttlValue, err := parseTTL(ttlAnnotation)
+	if err != nil {
+		log.Warnf("%s: \"%v\" is not a valid TTL value: %v", resource, ttlAnnotation, err)
+		return ttlNotConfigured
+	}
+	if ttlValue < ttlMinimum || ttlValue > ttlMaximum {
+		log.Warnf("TTL value %q must be between [%d, %d]", ttlValue, ttlMinimum, ttlMaximum)
+		return ttlNotConfigured
+	}
+	return endpoint.TTL(ttlValue)
+}
+
+// TODO: test
+// TODO: copied from source.go. Refactor to avoid duplication.
+// parseTTL parses TTL from string, returning duration in seconds.
+// parseTTL supports both integers like "600" and durations based
+// on Go Duration like "10m", hence "600" and "10m" represent the same value.
+//
+// Note: for durations like "1.5s" the fraction is omitted (resulting in 1 second
+// for the example).
+func parseTTL(s string) (ttlSeconds int64, err error) {
+	ttlDuration, errDuration := time.ParseDuration(s)
+	if errDuration != nil {
+		ttlInt, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, errDuration
+		}
+		return ttlInt, nil
+	}
+
+	return int64(ttlDuration.Seconds()), nil
+}
+
+// TODO: test
+func ProviderSpecificAnnotations(annotations map[string]string) (endpoint.ProviderSpecific, string) {
+	providerSpecificAnnotations := endpoint.ProviderSpecific{}
+
+	if v, exists := annotations[CloudflareProxiedKey]; exists {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  CloudflareProxiedKey,
+			Value: v,
+		})
+	}
+	if v, exists := annotations[CloudflareCustomHostnameKey]; exists {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  CloudflareCustomHostnameKey,
+			Value: v,
+		})
+	}
+	if getAliasFromAnnotations(annotations) {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  "alias",
+			Value: "true",
+		})
+	}
+	setIdentifier := ""
+	for k, v := range annotations {
+		if k == SetIdentifierKey {
+			setIdentifier = v
+		} else if strings.HasPrefix(k, "external-dns.alpha.kubernetes.io/aws-") {
+			attr := strings.TrimPrefix(k, "external-dns.alpha.kubernetes.io/aws-")
+			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+				Name:  fmt.Sprintf("aws/%s", attr),
+				Value: v,
+			})
+		} else if strings.HasPrefix(k, "external-dns.alpha.kubernetes.io/scw-") {
+			attr := strings.TrimPrefix(k, "external-dns.alpha.kubernetes.io/scw-")
+			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+				Name:  fmt.Sprintf("scw/%s", attr),
+				Value: v,
+			})
+		} else if strings.HasPrefix(k, "external-dns.alpha.kubernetes.io/ibmcloud-") {
+			attr := strings.TrimPrefix(k, "external-dns.alpha.kubernetes.io/ibmcloud-")
+			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+				Name:  fmt.Sprintf("ibmcloud-%s", attr),
+				Value: v,
+			})
+		} else if strings.HasPrefix(k, "external-dns.alpha.kubernetes.io/webhook-") {
+			// Support for wildcard annotations for webhook providers
+			attr := strings.TrimPrefix(k, "external-dns.alpha.kubernetes.io/webhook-")
+			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+				Name:  fmt.Sprintf("webhook/%s", attr),
+				Value: v,
+			})
+		}
+	}
+	return providerSpecificAnnotations, setIdentifier
+}
+
+// TODO: test
+func EndpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoint.TTL, providerSpecific endpoint.ProviderSpecific, setIdentifier string, resource string) []*endpoint.Endpoint {
+	var endpoints []*endpoint.Endpoint
+
+	var aTargets endpoint.Targets
+	var aaaaTargets endpoint.Targets
+	var cnameTargets endpoint.Targets
+
+	for _, t := range targets {
+		switch suitableType(t) {
+		case endpoint.RecordTypeA:
+			aTargets = append(aTargets, t)
+		case endpoint.RecordTypeAAAA:
+			aaaaTargets = append(aaaaTargets, t)
+		default:
+			cnameTargets = append(cnameTargets, t)
+		}
+	}
+
+	if len(aTargets) > 0 {
+		epA := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, ttl, aTargets...)
+		if epA != nil {
+			epA.ProviderSpecific = providerSpecific
+			epA.SetIdentifier = setIdentifier
+			if resource != "" {
+				epA.Labels[endpoint.ResourceLabelKey] = resource
+			}
+			endpoints = append(endpoints, epA)
+		}
+	}
+
+	if len(aaaaTargets) > 0 {
+		epAAAA := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeAAAA, ttl, aaaaTargets...)
+		if epAAAA != nil {
+			epAAAA.ProviderSpecific = providerSpecific
+			epAAAA.SetIdentifier = setIdentifier
+			if resource != "" {
+				epAAAA.Labels[endpoint.ResourceLabelKey] = resource
+			}
+			endpoints = append(endpoints, epAAAA)
+		}
+	}
+
+	if len(cnameTargets) > 0 {
+		epCNAME := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeCNAME, ttl, cnameTargets...)
+		if epCNAME != nil {
+			epCNAME.ProviderSpecific = providerSpecific
+			epCNAME.SetIdentifier = setIdentifier
+			if resource != "" {
+				epCNAME.Labels[endpoint.ResourceLabelKey] = resource
+			}
+			endpoints = append(endpoints, epCNAME)
+		}
+	}
+
+	return endpoints
+}
+
+func getAliasFromAnnotations(annotations map[string]string) bool {
+	aliasAnnotation, exists := annotations[aliasAnnotationKey]
+	return exists && aliasAnnotation == "true"
+}
+
+// suitableType returns the DNS resource record type suitable for the target.
+// In this case type A/AAAA for IPs and type CNAME for everything else.
+func suitableType(target string) string {
+	netIP, err := netip.ParseAddr(target)
+	if err == nil && netIP.Is4() {
+		return endpoint.RecordTypeA
+	} else if err == nil && netIP.Is6() {
+		return endpoint.RecordTypeAAAA
+	}
+	return endpoint.RecordTypeCNAME
+}
+
+// TODO: test
+func ParseIngress(ingress string) (namespace, name string, err error) {
+	parts := strings.Split(ingress, "/")
+	if len(parts) == 2 {
+		namespace, name = parts[0], parts[1]
+	} else if len(parts) == 1 {
+		name = parts[0]
+	} else {
+		err = fmt.Errorf("invalid ingress name (name or namespace/name) found %q", ingress)
+	}
+
+	return
+}
+
+// TODO: test
+func SelectorMatchesServiceSelector(selector, svcSelector map[string]string) bool {
+	for k, v := range selector {
+		if lbl, ok := svcSelector[k]; !ok || lbl != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TargetsFromTargetAnnotation gets endpoints from optional "target" annotation.
+// Returns empty endpoints array if none are found.
+func TargetsFromTargetAnnotation(annotations map[string]string) endpoint.Targets {
+	var targets endpoint.Targets
+
+	// Get the desired hostname of the ingress from the annotation.
+	targetAnnotation, exists := annotations[targetAnnotationKey]
+	if exists && targetAnnotation != "" {
+		// splits the hostname annotation and removes the trailing periods
+		targetsList := strings.Split(strings.Replace(targetAnnotation, " ", "", -1), ",")
+		for _, targetHostname := range targetsList {
+			targetHostname = strings.TrimSuffix(targetHostname, ".")
+			targets = append(targets, targetHostname)
+		}
+	}
+	return targets
+}
+
+func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, namespace string, selector map[string]string) endpoint.Targets {
+	targets := endpoint.Targets{}
+
+	services, err := svcInformer.Lister().Services(namespace).List(labels.Everything())
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+
+	for _, service := range services {
+		if !SelectorMatchesServiceSelector(selector, service.Spec.Selector) {
+			continue
+		}
+
+		if len(service.Spec.ExternalIPs) > 0 {
+			targets = append(targets, service.Spec.ExternalIPs...)
+			continue
+		}
+
+		for _, lb := range service.Status.LoadBalancer.Ingress {
+			if lb.IP != "" {
+				targets = append(targets, lb.IP)
+			} else if lb.Hostname != "" {
+				targets = append(targets, lb.Hostname)
+			}
+		}
+	}
+	return targets
+}
+
+// ParseAnnotationFilter parses an annotation filter string into a labels.Selector.
+// Returns nil if the annotation filter is invalid.
+func ParseAnnotationFilter(annotationFilter string) (labels.Selector, error) {
+	labelSelector, err := metav1.ParseToLabelSelector(annotationFilter)
+	if err != nil {
+		return nil, err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+	return selector, nil
+}

--- a/source/utils/utils_test.go
+++ b/source/utils/utils_test.go
@@ -1,0 +1,2 @@
+
+package utils


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Relates https://github.com/kubernetes-sigs/external-dns/issues/4473
Relates https://github.com/kubernetes-sigs/external-dns/issues/2798
Relates https://github.com/kubernetes-sigs/external-dns/issues/4786

WIP

The idea is to support `"networking.istio.io/v1alpha3"`  and `"networking.istio.io/v1"` for a period of time.

this require some refactoring beforehead, as in source directory code is tightly coupled


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
