### PR TITLE
refactor: move MergeEndpoints to endpoint package and elevate CNAME validation to pipeline layer

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -535,6 +535,11 @@ func (e *Endpoint) CheckEndpoint() bool {
 		if !e.isAlias() {
 			return e.Targets.ValidateIPRecord(recordType)
 		}
+	case RecordTypeCNAME:
+		if len(e.Targets) == 0 {
+			log.Debugf("Skipping CNAME endpoint %q with no targets", e.DNSName)
+			return false
+		}
 	case RecordTypeMX:
 		return e.Targets.ValidateMXRecord()
 	case RecordTypeSRV:

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1208,6 +1208,15 @@ func TestCheckEndpoint(t *testing.T) {
 			expected: true,
 		},
 		{
+			description: "CNAME record with no targets is invalid",
+			endpoint: Endpoint{
+				DNSName:    "example.com",
+				RecordType: RecordTypeCNAME,
+				Targets:    Targets{},
+			},
+			expected: false,
+		},
+		{
 			description: "MX record with alias=true is invalid",
 			endpoint: Endpoint{
 				DNSName:          "example.com",
@@ -1503,6 +1512,27 @@ func TestCheckEndpoint_PTRValidationLog(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckEndpoint_CNAMEDebugLog(t *testing.T) {
+	t.Run("CNAME with no targets logs debug", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+
+		ep := Endpoint{DNSName: "example.com", RecordType: RecordTypeCNAME, Targets: Targets{}}
+		ep.CheckEndpoint()
+
+		logtest.TestHelperLogContainsWithLogLevel("Skipping CNAME endpoint", log.DebugLevel, hook, t)
+		logtest.TestHelperLogContains("example.com", hook, t)
+	})
+
+	t.Run("CNAME with target does not log", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+
+		ep := Endpoint{DNSName: "example.com", RecordType: RecordTypeCNAME, Targets: Targets{"target.example.com"}}
+		ep.CheckEndpoint()
+
+		logtest.TestHelperLogNotContains("Skipping CNAME endpoint", hook, t)
+	})
 }
 
 func TestEndpoint_WithRefObject(t *testing.T) {

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -18,6 +18,7 @@ package endpoint
 
 import (
 	"net/netip"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,6 +86,44 @@ func EndpointsForHostname(hostname string, targets Targets, ttl TTL, providerSpe
 		endpoints = append(endpoints, ep)
 	}
 	return endpoints
+}
+
+// MergeEndpoints merges endpoints with the same key (DNSName + RecordType + SetIdentifier + RecordTTL)
+// by combining their targets. CNAME endpoints are not merged (per DNS spec) but are deduplicated.
+// This is useful when multiple resources (e.g., pods, nodes) contribute targets to the same DNS record.
+func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
+	if len(endpoints) == 0 {
+		return endpoints
+	}
+
+	endpointMap := make(map[EndpointKey]*Endpoint)
+
+	for _, ep := range endpoints {
+		key := EndpointKey{
+			DNSName:       ep.DNSName,
+			RecordType:    ep.RecordType,
+			SetIdentifier: ep.SetIdentifier,
+			RecordTTL:     ep.RecordTTL,
+		}
+		// CNAME records can only have one target per DNS spec, and should not be merged.
+		if ep.RecordType == RecordTypeCNAME && len(ep.Targets) > 0 {
+			key.Target = ep.Targets[0]
+		}
+		if existing, ok := endpointMap[key]; ok {
+			existing.Targets = append(existing.Targets, ep.Targets...)
+		} else {
+			endpointMap[key] = ep
+		}
+	}
+
+	result := make([]*Endpoint, 0, len(endpointMap))
+	for _, ep := range endpointMap {
+		slices.Sort(ep.Targets)
+		ep.Targets = slices.Compact(ep.Targets)
+		result = append(result, ep)
+	}
+
+	return result
 }
 
 // AttachRefObject sets the same ObjectReference on every endpoint in eps.

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -118,6 +118,168 @@ func TestHasEmptyEndpoints(t *testing.T) {
 	}
 }
 
+func TestMergeEndpoints(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []*Endpoint
+		expected []*Endpoint
+	}{
+		{
+			name:     "nil input returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input returns empty",
+			input:    []*Endpoint{},
+			expected: []*Endpoint{},
+		},
+		{
+			name: "single endpoint unchanged",
+			input: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+			},
+			expected: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			name: "different keys not merged",
+			input: []*Endpoint{
+				{DNSName: "a.example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+				{DNSName: "b.example.com", RecordType: RecordTypeA, Targets: Targets{"5.6.7.8"}},
+			},
+			expected: []*Endpoint{
+				{DNSName: "a.example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+				{DNSName: "b.example.com", RecordType: RecordTypeA, Targets: Targets{"5.6.7.8"}},
+			},
+		},
+		{
+			name: "same DNSName different RecordType not merged",
+			input: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+				{DNSName: "example.com", RecordType: RecordTypeAAAA, Targets: Targets{"2001:db8::1"}},
+			},
+			expected: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+				{DNSName: "example.com", RecordType: RecordTypeAAAA, Targets: Targets{"2001:db8::1"}},
+			},
+		},
+		{
+			name: "same key merged with sorted targets",
+			input: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"5.6.7.8"}},
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4"}},
+			},
+			expected: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.2.3.4", "5.6.7.8"}},
+			},
+		},
+		{
+			name: "multiple endpoints same key merged",
+			input: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"3.3.3.3"}},
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.1.1.1"}},
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"2.2.2.2"}},
+			},
+			expected: []*Endpoint{
+				{DNSName: "example.com", RecordType: RecordTypeA, Targets: Targets{"1.1.1.1", "2.2.2.2", "3.3.3.3"}},
+			},
+		},
+		{
+			name: "mixed merge and no merge",
+			input: []*Endpoint{
+				{DNSName: "a.example.com", RecordType: RecordTypeA, Targets: Targets{"1.1.1.1"}},
+				{DNSName: "b.example.com", RecordType: RecordTypeA, Targets: Targets{"2.2.2.2"}},
+				{DNSName: "a.example.com", RecordType: RecordTypeA, Targets: Targets{"3.3.3.3"}},
+			},
+			expected: []*Endpoint{
+				{DNSName: "a.example.com", RecordType: RecordTypeA, Targets: Targets{"1.1.1.1", "3.3.3.3"}},
+				{DNSName: "b.example.com", RecordType: RecordTypeA, Targets: Targets{"2.2.2.2"}},
+			},
+		},
+		{
+			name: "duplicate targets deduplicated",
+			input: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "1.2.3.4", "5.6.7.8"),
+			},
+			expected: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
+			},
+		},
+		{
+			name: "duplicate targets across merged endpoints deduplicated",
+			input: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
+			},
+			expected: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
+			},
+		},
+		{
+			name: "CNAME endpoints not merged",
+			input: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
+			},
+			expected: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
+			},
+		},
+		{
+			name: "identical CNAME endpoints deduplicated",
+			input: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+			},
+			expected: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+			},
+		},
+		{
+			name: "same key with different TTL not merged",
+			input: []*Endpoint{
+				NewEndpointWithTTL("example.com", RecordTypeA, 300, "1.2.3.4"),
+				NewEndpointWithTTL("example.com", RecordTypeA, 600, "5.6.7.8"),
+			},
+			expected: []*Endpoint{
+				NewEndpointWithTTL("example.com", RecordTypeA, 300, "1.2.3.4"),
+				NewEndpointWithTTL("example.com", RecordTypeA, 600, "5.6.7.8"),
+			},
+		},
+		{
+			name: "same DNSName and RecordType with different SetIdentifier not merged",
+			input: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
+				NewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
+			},
+			expected: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
+				NewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
+			},
+		},
+		{
+			name: "same DNSName, RecordType and SetIdentifier targets are merged",
+			input: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
+				NewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("us-east-1"),
+			},
+			expected: []*Endpoint{
+				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8").WithSetIdentifier("us-east-1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeEndpoints(tt.input)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
 func TestEndpointsForHostname(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -175,7 +175,7 @@ func (sc *ambassadorHostSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 		endpoints = append(endpoints, hostEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // endpointsFromHost extracts the endpoints from a Host object

--- a/source/connector.go
+++ b/source/connector.go
@@ -72,7 +72,7 @@ func (cs *connectorSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 
 	log.Debugf("Received endpoints: %#v", endpoints)
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (cs *connectorSource) AddEventHandler(_ context.Context, _ func()) {}

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -160,7 +160,7 @@ func (sc *httpProxySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		endpoints = append(endpoints, hpEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (sc *httpProxySource) endpointsFromTemplate(httpProxy *projectcontour.HTTPProxy) ([]*endpoint.Endpoint, error) {

--- a/source/crd.go
+++ b/source/crd.go
@@ -254,7 +254,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 		}
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (cs *crdSource) watch(ctx context.Context, opts *metav1.ListOptions) (watch.Interface, error) {

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -128,7 +128,7 @@ func (ts *f5TransportServerSource) Endpoints(_ context.Context) ([]*endpoint.End
 
 	endpoints := ts.endpointsFromTransportServers(transportServers)
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (ts *f5TransportServerSource) AddEventHandler(_ context.Context, handler func()) {

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -127,7 +127,7 @@ func (vs *f5VirtualServerSource) Endpoints(_ context.Context) ([]*endpoint.Endpo
 
 	endpoints := vs.endpointsFromVirtualServers(virtualServers)
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (vs *f5VirtualServerSource) AddEventHandler(_ context.Context, handler func()) {

--- a/source/fake.go
+++ b/source/fake.go
@@ -76,7 +76,7 @@ func (sc *fakeSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 		endpoints[i] = sc.generateEndpoint()
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (sc *fakeSource) generateEndpoint() *endpoint.Endpoint {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -295,7 +295,7 @@ func (src *gatewayRouteSource) Endpoints(_ context.Context) ([]*endpoint.Endpoin
 
 		endpoints = append(endpoints, routeEndpoints...)
 	}
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func namespacedName(namespace, name string) types.NamespacedName {

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -257,7 +257,7 @@ func (gs *glooSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 			endpoints = append(endpoints, proxyEndpoints...)
 		}
 	}
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (gs *glooSource) generateEndpointsFromProxy(proxy *proxy, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -184,7 +184,7 @@ func (sc *ingressSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		endpoints = append(endpoints, ingEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (sc *ingressSource) endpointsFromTemplate(ing *networkv1.Ingress) ([]*endpoint.Endpoint, error) {

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -196,7 +196,7 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 		endpoints = append(endpoints, gwEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // AddEventHandler adds an event handler that should be triggered if the watched Istio Gateway changes.

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -193,7 +193,7 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 		endpoints = append(endpoints, gwEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // AddEventHandler adds an event handler that should be triggered if the watched Istio VirtualService changes.

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -157,7 +157,7 @@ func (sc *kongTCPIngressSource) Endpoints(_ context.Context) ([]*endpoint.Endpoi
 		endpoints = append(endpoints, ingressEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // endpointsFromTCPIngress extracts the endpoints from a TCPIngress object

--- a/source/node.go
+++ b/source/node.go
@@ -159,7 +159,7 @@ func (ns *nodeSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 		endpoints = append(endpoints, nodeEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (ns *nodeSource) AddEventHandler(_ context.Context, handler func()) {
@@ -205,7 +205,7 @@ func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]
 		}
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // nodeAddress returns the node's externalIP and if that's not found, the node's internalIP

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -153,7 +153,7 @@ func (ors *ocpRouteSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		endpoints = append(endpoints, orEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routev1.Route) ([]*endpoint.Endpoint, error) {

--- a/source/pod.go
+++ b/source/pod.go
@@ -151,7 +151,7 @@ func (ps *podSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) 
 		endpoints = append(endpoints, podEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (ps *podSource) endpointsFromPodAnnotations(pod *v1.Pod) []*endpoint.Endpoint {

--- a/source/service.go
+++ b/source/service.go
@@ -288,7 +288,7 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		})
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // extractHeadlessEndpoints extracts endpoints from a headless service using the "Endpoints" Kubernetes API resource

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -288,7 +288,7 @@ func (sc *routeGroupSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, 
 		endpoints = append(endpoints, eps...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.Endpoint, error) {

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -208,7 +208,7 @@ func (ts *traefikSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		endpoints = append(endpoints, oldIngressRouteUdpEndpoints...)
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // ingressRouteEndpoints extracts endpoints from all IngressRoute objects

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -204,7 +204,7 @@ func (us *unstructuredSource) endpointsFromInformer(informer kubeinformers.Gener
 		}
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // endpointsFromTemplate creates endpoints using DNS names from the FQDN template.
@@ -261,7 +261,7 @@ func (us *unstructuredSource) endpointsFromFQDNTargetTemplate(el *unstructuredWr
 		endpoints = append(endpoints, endpoint.NewEndpoint(host, endpoint.SuitableType(target), target))
 	}
 
-	return MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 // AddEventHandler adds an event handler that is called when resources change.

--- a/source/utils.go
+++ b/source/utils.go
@@ -15,12 +15,7 @@ package source
 
 import (
 	"fmt"
-	"slices"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
-
-	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // ParseIngress parses an ingress string in the format "namespace/name" or "name".
@@ -52,57 +47,4 @@ func MatchesServiceSelector(selector, svcSelector map[string]string) bool {
 		}
 	}
 	return true
-}
-
-// MergeEndpoints merges endpoints with the same key (DNSName + RecordType + SetIdentifier + RecordTTL)
-// by combining their targets. CNAME endpoints are not merged (per DNS spec) but are deduplicated.
-// This is useful when multiple resources (e.g., pods, nodes) contribute targets to the same DNS record.
-//
-// TODO: move this to endpoint/utils.go
-func MergeEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
-	if len(endpoints) == 0 {
-		return endpoints
-	}
-
-	endpointMap := make(map[endpoint.EndpointKey]*endpoint.Endpoint)
-	cnameTargets := make(map[string]string) // DNSName+SetIdentifier -> first target seen
-
-	for _, ep := range endpoints {
-		if ep.RecordType == endpoint.RecordTypeCNAME && len(ep.Targets) == 0 {
-			log.Debugf("Skipping CNAME endpoint %q with no targets", ep.DNSName)
-			continue
-		}
-
-		key := endpoint.EndpointKey{
-			DNSName:       ep.DNSName,
-			RecordType:    ep.RecordType,
-			SetIdentifier: ep.SetIdentifier,
-			RecordTTL:     ep.RecordTTL,
-		}
-		// CNAME records can only have one target per DNS spec, and they should not be merged.
-		if ep.RecordType == endpoint.RecordTypeCNAME {
-			key.Target = ep.Targets[0]
-			cnameKey := ep.DNSName + "/" + ep.SetIdentifier
-			if existing, ok := cnameTargets[cnameKey]; ok && existing != ep.Targets[0] {
-				// This will be caught by the provider when it tries to create the record, but log a warning here to make it more obvious.
-				// TODO: add metric for CNAME conflicts
-				log.Warnf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, existing, ep.DNSName, ep.Targets[0])
-			}
-			cnameTargets[cnameKey] = ep.Targets[0]
-		}
-		if existing, ok := endpointMap[key]; ok {
-			existing.Targets = append(existing.Targets, ep.Targets...)
-		} else {
-			endpointMap[key] = ep
-		}
-	}
-
-	result := make([]*endpoint.Endpoint, 0, len(endpointMap))
-	for _, ep := range endpointMap {
-		slices.Sort(ep.Targets)
-		ep.Targets = slices.Compact(ep.Targets)
-		result = append(result, ep)
-	}
-
-	return result
 }

--- a/source/utils_test.go
+++ b/source/utils_test.go
@@ -16,14 +16,12 @@ package source
 import (
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
-	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source/types"
 )
 
@@ -126,178 +124,6 @@ func TestSelectorMatchesService(t *testing.T) {
 	}
 }
 
-func TestMergeEndpoints(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []*endpoint.Endpoint
-		expected []*endpoint.Endpoint
-	}{
-		{
-			name:     "nil input returns nil",
-			input:    nil,
-			expected: nil,
-		},
-		{
-			name:     "empty input returns empty",
-			input:    []*endpoint.Endpoint{},
-			expected: []*endpoint.Endpoint{},
-		},
-		{
-			name: "single endpoint unchanged",
-			input: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-			},
-			expected: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-			},
-		},
-		{
-			name: "different keys not merged",
-			input: []*endpoint.Endpoint{
-				{DNSName: "a.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "b.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"5.6.7.8"}},
-			},
-			expected: []*endpoint.Endpoint{
-				{DNSName: "a.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "b.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"5.6.7.8"}},
-			},
-		},
-		{
-			name: "same DNSName different RecordType not merged",
-			input: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1"}},
-			},
-			expected: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1"}},
-			},
-		},
-		{
-			name: "same key merged with sorted targets",
-			input: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"5.6.7.8"}},
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-			},
-			expected: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4", "5.6.7.8"}},
-			},
-		},
-		{
-			name: "multiple endpoints same key merged",
-			input: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"3.3.3.3"}},
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"2.2.2.2"}},
-			},
-			expected: []*endpoint.Endpoint{
-				{DNSName: "example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "2.2.2.2", "3.3.3.3"}},
-			},
-		},
-		{
-			name: "mixed merge and no merge",
-			input: []*endpoint.Endpoint{
-				{DNSName: "a.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "b.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"2.2.2.2"}},
-				{DNSName: "a.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"3.3.3.3"}},
-			},
-			expected: []*endpoint.Endpoint{
-				{DNSName: "a.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "3.3.3.3"}},
-				{DNSName: "b.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"2.2.2.2"}},
-			},
-		},
-		{
-			name: "duplicate targets deduplicated",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4", "1.2.3.4", "5.6.7.8"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8"),
-			},
-		},
-		{
-			name: "duplicate targets across merged endpoints deduplicated",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8"),
-			},
-		},
-		{
-			name: "CNAME endpoints not merged",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
-			},
-		},
-		{
-			name: "CNAME with no targets is skipped",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-			},
-		},
-		{
-			name: "identical CNAME endpoints deduplicated",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-			},
-		},
-		{
-			name: "same key with different TTL not merged",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, 300, "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, 600, "5.6.7.8"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, 300, "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, 600, "5.6.7.8"),
-			},
-		},
-		{
-			name: "same DNSName and RecordType with different SetIdentifier not merged",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
-			},
-		},
-		{
-			name: "same DNSName, RecordType and SetIdentifier targets are merged",
-			input: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "5.6.7.8").WithSetIdentifier("us-east-1"),
-			},
-			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8").WithSetIdentifier("us-east-1"),
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := MergeEndpoints(tt.input)
-			assert.ElementsMatch(t, tt.expected, result)
-		})
-	}
-}
-
 func TestMergeEndpoints_RefObjects(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -373,56 +199,8 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MergeEndpoints(tt.input())
+			result := endpoint.MergeEndpoints(tt.input())
 			tt.expected(t, result)
 		})
 	}
-}
-
-func TestMergeEndpointsLogging(t *testing.T) {
-	t.Run("warns on CNAME conflict", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-
-		MergeEndpoints([]*endpoint.Endpoint{
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
-		})
-
-		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
-		logtest.TestHelperLogContains("example.com CNAME a.elb.com", hook, t)
-		logtest.TestHelperLogContains("example.com CNAME b.elb.com", hook, t)
-	})
-
-	t.Run("no warning for identical CNAMEs", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-
-		MergeEndpoints([]*endpoint.Endpoint{
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
-		})
-
-		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
-	})
-
-	t.Run("no warning for same DNSName with different SetIdentifier", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-
-		MergeEndpoints([]*endpoint.Endpoint{
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com").WithSetIdentifier("weight-1"),
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com").WithSetIdentifier("weight-2"),
-		})
-
-		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
-	})
-
-	t.Run("debug log for CNAME with no targets", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
-
-		MergeEndpoints([]*endpoint.Endpoint{
-			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME),
-		})
-
-		logtest.TestHelperLogContainsWithLogLevel("Skipping CNAME endpoint", log.DebugLevel, hook, t)
-		logtest.TestHelperLogContains("example.com", hook, t)
-	})
 }

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -41,6 +41,7 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 	log.Debug("dedupSource: collecting endpoints and removing duplicates")
 	result := make([]*endpoint.Endpoint, 0)
 	collected := make(map[string]struct{})
+	cnameTargets := make(map[string]string) // DNSName+"/"+SetIdentifier -> first target seen
 
 	endpoints, err := ms.source.Endpoints(ctx)
 	if err != nil {
@@ -60,6 +61,16 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 
 		if len(ep.Targets) > 1 {
 			ep.Targets = endpoint.NewTargets(ep.Targets...)
+		}
+
+		if ep.RecordType == endpoint.RecordTypeCNAME {
+			cnameKey := ep.DNSName + "/" + ep.SetIdentifier
+			if existing, ok := cnameTargets[cnameKey]; ok && existing != ep.Targets[0] {
+				// TODO: add metric for CNAME conflicts
+				log.Warnf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, existing, ep.DNSName, ep.Targets[0])
+			} else if !ok {
+				cnameTargets[cnameKey] = ep.Targets[0]
+			}
 		}
 
 		identifier := strings.Join([]string{ep.RecordType, ep.DNSName, ep.SetIdentifier, ep.Targets.String()}, "/")

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -419,6 +419,15 @@ func TestDedupSource_WarnsOnInvalidEndpoint(t *testing.T) {
 			},
 			wantLogMsg: "Skipping endpoint [:web.example.org] due to invalid configuration [PTR:other.example.org]",
 		},
+		{
+			name: "CNAME with no targets",
+			endpoint: &endpoint.Endpoint{
+				DNSName:    "example.org",
+				RecordType: endpoint.RecordTypeCNAME,
+				Targets:    endpoint.Targets{},
+			},
+			wantLogMsg: "Skipping endpoint [:example.org] due to invalid configuration [CNAME:]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -637,4 +646,56 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			mockSource.AssertExpectations(t)
 		})
 	}
+}
+
+func TestDedupSource_WarnsCNAMEConflict(t *testing.T) {
+	t.Run("warns on CNAME conflict", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+
+		mockSource := new(testutils.MockSource)
+		mockSource.On("Endpoints").Return([]*endpoint.Endpoint{
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
+		}, nil)
+
+		src := NewDedupSource(mockSource)
+		_, err := src.Endpoints(t.Context())
+		require.NoError(t, err)
+
+		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
+		logtest.TestHelperLogContains("example.com CNAME a.elb.com", hook, t)
+		logtest.TestHelperLogContains("example.com CNAME b.elb.com", hook, t)
+	})
+
+	t.Run("no warning for identical CNAMEs", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+
+		mockSource := new(testutils.MockSource)
+		mockSource.On("Endpoints").Return([]*endpoint.Endpoint{
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+		}, nil)
+
+		src := NewDedupSource(mockSource)
+		_, err := src.Endpoints(t.Context())
+		require.NoError(t, err)
+
+		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
+	})
+
+	t.Run("no warning for same DNSName with different SetIdentifier", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+
+		mockSource := new(testutils.MockSource)
+		mockSource.On("Endpoints").Return([]*endpoint.Endpoint{
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com").WithSetIdentifier("weight-1"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com").WithSetIdentifier("weight-2"),
+		}, nil)
+
+		src := NewDedupSource(mockSource)
+		_, err := src.Endpoints(t.Context())
+		require.NoError(t, err)
+
+		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
+	})
 }

--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -231,3 +231,122 @@ scenarios:
       - dnsName: example.local
         targets: ["1.2.3.4"]
         recordType: A
+
+  - name: cname-dedup-across-sources
+    description: >
+      Test that dedupSource correctly deduplicates identical CNAME endpoints from
+      different sources. Both the Service and the Ingress resolve example.local to
+      the same hostname target (elb.example.com), producing identical CNAME endpoints.
+      The dedupSource key includes Targets.String(), so the duplicate is dropped and
+      only one CNAME record survives.
+    config:
+      sources: ["service", "ingress"]
+    resources:
+      - resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+            namespace: default
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: example.local
+          spec:
+            selector:
+              app.kubernetes.io/name: MyApp
+            type: LoadBalancer
+          status:
+            loadBalancer:
+              ingress:
+                - hostname: elb.example.com
+      - resource:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: test-ingress
+            namespace: default
+            annotations:
+              kubernetes.io/ingress.class: "nginx"
+          spec:
+            rules:
+              - host: example.local
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: test-service
+                          port:
+                            number: 80
+          status:
+            loadBalancer:
+              ingress:
+                - hostname: elb.example.com
+    expected:
+      - dnsName: example.local
+        targets: ["elb.example.com"]
+        recordType: CNAME
+
+  - name: cname-conflict-across-sources
+    description: >
+      Documents known behavior: when a Service and an Ingress map the same hostname
+      to different CNAME targets, dedupSource warns about the invalid DNS configuration
+      but keeps both endpoints (they have different Targets.String() so neither is a
+      duplicate). Two CNAME records survive for the same name.
+      dedupSource intentionally does not drop the conflicting endpoint because it is
+      a deduplication layer, not a conflict resolution layer. The provider has more
+      context — for example, a weighted-routing provider may legitimately want two
+      CNAMEs for the same name with different SetIdentifiers, and that case is already
+      handled correctly (the cnameKey includes SetIdentifier, so weighted CNAMEs do
+      not trigger a conflict). For plain conflicts without SetIdentifiers, the provider
+      will surface the error.
+    config:
+      sources: ["service", "ingress"]
+    resources:
+      - resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+            namespace: default
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: example.local
+          spec:
+            selector:
+              app.kubernetes.io/name: MyApp
+            type: LoadBalancer
+          status:
+            loadBalancer:
+              ingress:
+                - hostname: a.elb.example.com
+      - resource:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: test-ingress
+            namespace: default
+            annotations:
+              kubernetes.io/ingress.class: "nginx"
+          spec:
+            rules:
+              - host: example.local
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: test-service
+                          port:
+                            number: 80
+          status:
+            loadBalancer:
+              ingress:
+                - hostname: b.elb.example.com
+    expected:
+      - dnsName: example.local
+        targets: ["a.elb.example.com"]
+        recordType: CNAME
+      - dnsName: example.local
+        targets: ["b.elb.example.com"]
+        recordType: CNAME


### PR DESCRIPTION
## What does it do ?

  - Moved MergeEndpoints to endpoint/utils.go; all source callers updated
  - CNAME conflict detection moved to dedupSource — now catches conflicts across sources
  - Empty-target CNAME filtering moved to CheckEndpoint() with debug log
  - Tests redistributed accordingly
  - Two integration scenarios added: cross-source CNAME dedup and cross-source CNAME conflict

## Motivation

MergeEndpoints had no source-specific dependencies (there was even a TODO to move it) and its CNAME validations fired only within a single source, missing cross-source conflicts.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
